### PR TITLE
Update for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,119 @@
+name: continuous-integration
+
+on:
+  push:
+    branches:
+    - main
+    - v[1-9].*
+    - prep-v[1-9].*
+    tags:
+    - v[1-9].*
+  pull_request:
+    branches:
+    - main
+    - v[1-9].*
+    - prep-v[1-9].*
+
+env:
+  BUILDTIME_BASE: "golang:1.21.4"
+  RUNTIME_BASE: "gcr.io/distroless/static"
+  GO_VERSION: "~1.21.4"
+  GO_CACHE: "/home/runner/.cache/go-build"
+  GO_MOD_CACHE: "/home/runner/go/pkg/mod"
+
+jobs:
+  # Builds ntopng-exporter binary
+  ci-build-ntopng-exporter:
+    name: ci-build-ntopng-exporter
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
+
+    - name: Install dependencies
+      run: |
+        go get .
+
+    - name: Build
+      run: go build -v -ldflags '-s -w' ./...
+      env:
+        CGO_ENABLED: "0"
+
+  # Builds Container only if a tag or a pull request from a source branch within the repository
+  ci-build-container:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name != 'pull_request' ||
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]' &&
+          startsWith(github.ref, 'refs/tags/v'))
+      }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker (RC, Tag)
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: aauren/ntopng-exporter
+
+    # Tagging a proper release, update latest
+    - name: Build and push - New Tag
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        platforms: |
+          linux/amd64
+          linux/arm64
+          linux/arm/v7
+          linux/s390x
+          linux/ppc64le
+        push: true
+        build-args: |
+          BUILDTIME_BASE=${{ env.BUILDTIME_BASE }}
+          RUNTIME_BASE=${{ env.RUNTIME_BASE }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+  # Runs Go Releaser on Tag Event
+  ci-goreleaser-tag:
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+      id: go
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        version: latest
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ fabric.properties
 # CodeStream plugin
 # https://plugins.jetbrains.com/plugin/12206-codestream
 .idea/codestream.xml
+
+# Ignore .act directory
+.act

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,9 +10,15 @@ builds:
   - darwin
   goarch:
   - arm64
+  - arm
   - amd64
   - 386
-  gobinary: "go1.21.3"
+  - s390x
+  - ppc64le
+  - riscv64
+  goarm:
+  - 6
+  - 7
 archives:
 - id: primary
   name_template: >-
@@ -21,6 +27,7 @@ archives:
     {{- else }}{{ title .Os }}{{end}}_
     {{- if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{end}}
+    {{ with .Arm }}v{{ . }}{{ end }}
   format_overrides:
   - goos: windows
     format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,14 @@
+---
+release:
+  draft: true
+  prerelease: auto
+  header: |
+    ## Summary
+
+    ## Contributions
+
+    ## Changelog
+
 before:
   hooks:
   - go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.17.6 as build
+ARG BUILDTIME_BASE=golang:1.21.4
+ARG RUNTIME_BASE=gcr.io/distroless/static:latest
+FROM ${BUILDTIME_BASE} as builder
 
 WORKDIR /go/src/app
 ENV CGO_ENABLED=0
@@ -7,7 +9,7 @@ EXPOSE 3001
 
 RUN go build -ldflags '-s -w' -o /go/bin/ntopng-exporter
 
-FROM gcr.io/distroless/static
+FROM ${RUNTIME_BASE}
 
-COPY --from=build /go/bin/ntopng-exporter /
+COPY --from=builder /go/bin/ntopng-exporter /
 CMD ["/ntopng-exporter"]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ exposed, either with a dynamic port allocation with the `--publish-all` option o
 docker invocation that runs the latest published ntopng-exporter would look something like this:
 
 ```sh
-docker run --volume /some/directory/with/config:/config --publish 3001:3001 nresare/ntopng-exporter
+docker run --volume /some/directory/with/config:/config --publish 3001:3001 aauren/ntopng-exporter
 ```
 
 ### Root Concerns


### PR DESCRIPTION
Fixes #6 

Creates a build job on PRs and pushes and sets up automatic publishing of releases and container images on tag.

Since I do not own nresare/ntopng-exporter this also updates docker publishes to aauren/ntopng-exporter.